### PR TITLE
✨ Feat : 비밀번호 초기화 요청 / 비밀번호 변경 API 구현

### DIFF
--- a/src/controllers/authController.ts
+++ b/src/controllers/authController.ts
@@ -3,6 +3,8 @@ import {
   registerUser,
   loginUser,
   rotateRefreshToken,
+  requestPasswordResetService,
+  confirmPasswordResetService,
 } from "../services/authService";
 import { accessCookieOptions, refreshCookieOptions } from "../config/auth";
 import { logger } from "../utils/logger";
@@ -111,4 +113,48 @@ export async function logout(req: Request, res: Response) {
 
   logger.info("유저 로그아웃");
   return res.status(200).json({ message: "로그아웃에 성공했습니다." });
+}
+export async function requestPasswordReset(req: Request, res: Response) {
+  const { email, name } = req.body ?? {};
+
+  if (!email || !name) {
+    return res.status(400).json({ error: "INVALID_INPUT" });
+  }
+
+  const result = await requestPasswordResetService({ email, name });
+
+  if (!result.ok) {
+    return res.status(404).json({ error: "USER_NOT_FOUND" });
+  }
+
+  logger.info("비밀번호 재설정 요청 성공", { email });
+  return res.status(200).json({
+    message: "사용자 확인 완료",
+    reset_token: result.resetToken,
+    expires_in: result.expiresIn,
+  });
+}
+
+export async function confirmPasswordReset(req: Request, res: Response) {
+  const { reset_token: resetToken, password: newPassword } = req.body ?? {};
+
+  if (!resetToken || !newPassword) {
+    return res.status(400).json({ error: "INVALID_INPUT" });
+  }
+
+  /*
+  if (String(newPassword).length < 8) {
+    return res.status(400).json({ error: "WEAK_PASSWORD" });
+  }
+  */
+
+  const result = await confirmPasswordResetService({ resetToken, newPassword });
+
+  if (!result.ok) {
+    return res.status(401).json({ error: result.code });
+  }
+
+  logger.info("비밀번호 재설정 완료");
+
+  return res.status(200).json({ message: "비밀번호가 변경되었습니다." });
 }

--- a/src/controllers/usersController.ts
+++ b/src/controllers/usersController.ts
@@ -51,6 +51,7 @@ export async function withdrawUser(req: Request, res: Response) {
  */
 export async function uploadMyProfileImage(req: Request, res: Response) {
   const user = res.locals.user as { id: string; email: string } | undefined;
+
   if (!user?.id) return res.status(401).json({ error: "UNAUTHORIZED" });
 
   const file = req.file;
@@ -71,12 +72,10 @@ export async function uploadMyProfileImage(req: Request, res: Response) {
       contentType: file.mimetype,
     });
 
-    return res
-      .status(200)
-      .json({
-        message: "프로필 이미지가 반영되었습니다.",
-        profileImageUrl: result.profileImageUrl,
-      });
+    return res.status(200).json({
+      message: "프로필 이미지가 반영되었습니다.",
+      profileImageUrl: result.profileImageUrl,
+    });
   } catch (e) {
     logger.error("프로필 이미지 업로드 요청 실패", {
       userId: user.id,
@@ -93,16 +92,21 @@ export async function uploadMyProfileImage(req: Request, res: Response) {
  */
 export async function deleteMyProfileImage(req: Request, res: Response) {
   const user = res.locals.user as { id: string; email: string } | undefined;
+
   if (!user?.id) return res.status(401).json({ error: "UNAUTHORIZED" });
+
   try {
     logger.info("프로필 이미지 삭제 요청", { userId: user.id });
+
     await deleteProfileImage({ userId: user.id });
+
     return res.status(200).json({ message: "프로필 이미지를 삭제했습니다." });
   } catch (e) {
     logger.error("프로필 이미지 삭제 요청 실패", {
       userId: user.id,
       error: e instanceof Error ? e.message : String(e),
     });
+
     return res.status(500).json({ error: "PROFILE_IMAGE_DELETE_FAILED" });
   }
 }

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -5,6 +5,8 @@ import {
   me,
   logout,
   refresh,
+  requestPasswordReset,
+  confirmPasswordReset,
 } from "../controllers/authController";
 import { requireAuth } from "../middlewares/requireAuth";
 
@@ -229,5 +231,8 @@ router.post("/logout", logout);
  *                   example: TOKEN_REUSE_DETECTED
  */
 router.post("/refresh", refresh);
+
+router.post("/password/reset", requestPasswordReset);
+router.put("/password/reset", confirmPasswordReset);
 
 export default router;

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -212,3 +212,73 @@ export async function loginUser({
     refreshToken,
   };
 }
+// 메모리 저장(개발용). 운영에서는 redis/DB 권장
+const resetSessionStore = new Map<
+  string,
+  { userId: string; expiresAt: number }
+>();
+
+function generateResetToken() {
+  return crypto.randomBytes(32).toString("hex");
+}
+
+export async function requestPasswordResetService(params: {
+  email: string;
+  name: string;
+}) {
+  const { email, name } = params;
+
+  const { data: user, error } = await supabase
+    .from("users")
+    .select("id, email, name")
+    .eq("email", email)
+    .eq("name", name)
+    .single();
+
+  if (error || !user) {
+    return { ok: false as const, code: "USER_NOT_FOUND" as const };
+  }
+
+  const resetToken = generateResetToken();
+  const expiresAt = Date.now() + 10 * 60 * 1000; // 10분
+  resetSessionStore.set(resetToken, {
+    userId: user.id,
+    expiresAt,
+  });
+
+  return {
+    ok: true as const,
+    resetToken,
+    expiresIn: 600,
+  };
+}
+
+export async function confirmPasswordResetService(params: {
+  resetToken: string;
+  newPassword: string;
+}) {
+  const { resetToken, newPassword } = params;
+
+  const session = resetSessionStore.get(resetToken);
+  if (!session) {
+    return { ok: false as const, code: "INVALID_RESET_TOKEN" as const };
+  }
+
+  if (session.expiresAt < Date.now()) {
+    resetSessionStore.delete(resetToken);
+    return { ok: false as const, code: "RESET_TOKEN_EXPIRED" as const };
+  }
+
+  const passwordHash = await bcrypt.hash(newPassword, 12);
+
+  const { error } = await supabase
+    .from("users")
+    .update({ password_hash: passwordHash })
+    .eq("id", session.userId);
+  if (error) {
+    throw new Error(error.message);
+  }
+  // 1회용 토큰
+  resetSessionStore.delete(resetToken);
+  return { ok: true as const };
+}


### PR DESCRIPTION
## 제목
✨ Feat : 비밀번호 초기화 요청 / 비밀번호 변경 API 구현

## 개요 (Summary)

## 관련 이슈 / 기획 문서
- 관련 이슈: #25
---

## 1. 변경 유형 (Type)
- [x] 기능 추가 (Feature)
- [ ] 버그 수정 (Bug fix)
- [ ] 리팩터링 (Refactor)
- [ ] 문서 (Docs)
- [ ] 인프라/배포 (Infra/DevOps)
- [ ] 기타 (Other, 아래에 설명)
---

## 2. 백엔드 상세 내용 (What changed)
- [x] API 추가/변경 (`/auth`, `/schedules`, `/resumes`, `/job-postings` 등)
- [ ] 서비스/도메인 로직
- [ ] 배치/크롤러 로직
- [ ] 인증/인가, 알림(메일 등)

변경 요약:
-
---
### 3. DB / ERD
- [ ] 테이블/컬럼 추가·수정
- [ ] 인덱스/제약 조건 변경
- [ ] 마이그레이션 스크립트 추가

변경 요약:
-
---

## 기타 (Notes)
- 리뷰어가 알면 좋을 추가 맥락이나 TODO가 있다면 적어주세요.
close #25 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 비밀번호 재설정 기능이 추가되었습니다. 사용자는 등록된 이메일과 이름으로 비밀번호 재설정을 요청하고, 제공받은 토큰을 통해 새로운 비밀번호를 설정할 수 있습니다. 재설정 토큰은 10분 동안 유효합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->