### PR TITLE
🛠️ Fix : 로그인 시 이미지 반환 로직 추가

### DIFF
--- a/src/lib/jwt.ts
+++ b/src/lib/jwt.ts
@@ -4,6 +4,7 @@ import { authConfig } from "../config/auth";
 type JwtPayload = {
   id: string;
   email: string;
+  profile_image_url: string | null;
 };
 
 export function signAccessToken(payload: JwtPayload) {

--- a/src/middlewares/optionalAuth.ts
+++ b/src/middlewares/optionalAuth.ts
@@ -9,7 +9,11 @@ export function optionalAuth(req: Request, res: Response, next: NextFunction) {
 
   try {
     const payload = verifyAccessToken(token);
-    res.locals.user = { id: payload.id, email: payload.email };
+    res.locals.user = {
+      id: payload.id,
+      email: payload.email,
+      profile_image_url: payload.profile_image_url,
+    };
   } catch {
     //토큰이 없으면 익명사용자
   }

--- a/src/middlewares/requireAuth.ts
+++ b/src/middlewares/requireAuth.ts
@@ -8,7 +8,11 @@ export function requireAuth(req: Request, res: Response, next: NextFunction) {
   }
   try {
     const payload = verifyAccessToken(token);
-    res.locals.user = { id: payload.id, email: payload.email };
+    res.locals.user = {
+      id: payload.id,
+      email: payload.email,
+      profile_image_url: payload.profile_image_url,
+    };
     next();
   } catch {
     return res.status(401).json({ error: "UNAUTHORIZED" });

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -71,6 +71,10 @@ const router = Router();
  *         name:
  *           type: string
  *           example: 홍길동
+ *         profile_image_url:
+ *           type: string
+ *           nullable: true
+ *           example: https://xxx.supabase.co/storage/v1/object/public/profile-images/users/xxx/profile.webp
  */
 
 /**

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -37,7 +37,7 @@ function calcRefreshExpiryDate() {
 export async function rotateRefreshToken(rawRefreshToken: string) {
   // 1) JWT 자체 검증 (서명/만료)
   // 여기서 실패하면 "애초에 신뢰할 수 없는 토큰"이므로 401 처리한다.
-  let payload: { id: string; email: string };
+  let payload: { id: string; email: string; profile_image_url: string | null };
   try {
     payload = verifyRefreshToken(rawRefreshToken);
   } catch (error) {
@@ -87,10 +87,12 @@ export async function rotateRefreshToken(rawRefreshToken: string) {
   const newAccessToken = signAccessToken({
     id: payload.id,
     email: payload.email,
+    profile_image_url: payload.profile_image_url,
   });
   const newRefreshToken = signRefreshToken({
     id: payload.id,
     email: payload.email,
+    profile_image_url: payload.profile_image_url,
   });
   const newHash = sha256(newRefreshToken);
 
@@ -162,7 +164,7 @@ export async function loginUser({
   // 1) 유저 조회
   const { data: user, error } = await supabase
     .from("users")
-    .select("id, email, password_hash, name")
+    .select("id, email, password_hash, name, profile_image_url")
     .eq("email", email)
     .single();
 
@@ -181,11 +183,13 @@ export async function loginUser({
   const accessToken = signAccessToken({
     id: user.id,
     email: user.email,
+    profile_image_url: user.profile_image_url,
   });
 
   const refreshToken = signRefreshToken({
     id: user.id,
     email: user.email,
+    profile_image_url: user.profile_image_url,
   });
 
   // 4) refresh token DB 저장 (해시된 토큰으로 저장해야 DB가 털려도 원문이 없음)
@@ -207,7 +211,12 @@ export async function loginUser({
 
   return {
     ok: true as const,
-    user: { id: user.id, email: user.email, name: user.name },
+    user: {
+      id: user.id,
+      email: user.email,
+      name: user.name,
+      profile_image_url: user.profile_image_url,
+    },
     accessToken,
     refreshToken,
   };


### PR DESCRIPTION
## 제목
🛠️ Fix : 로그인 시 이미지 반환 로직 추가

## 개요 (Summary)
- 관련 스웨거 수정
- 반환하는 access_token, refresh_token, user 객체에 profile_image_url 속성 추가

## 관련 이슈 / 기획 문서
- 관련 이슈: #51 
---

## 1. 변경 유형 (Type)
- [x] 기능 추가 (Feature)
- [ ] 버그 수정 (Bug fix)
- [ ] 리팩터링 (Refactor)
- [ ] 문서 (Docs)
- [ ] 인프라/배포 (Infra/DevOps)
- [ ] 기타 (Other, 아래에 설명)
---

## 2. 백엔드 상세 내용 (What changed)
- [ ] API 추가/변경 (`/auth`, `/schedules`, `/resumes`, `/job-postings` 등)
- [x] 서비스/도메인 로직
- [ ] 배치/크롤러 로직
- [ ] 인증/인가, 알림(메일 등)

변경 요약:
-
---
### 3. DB / ERD
- [ ] 테이블/컬럼 추가·수정
- [ ] 인덱스/제약 조건 변경
- [ ] 마이그레이션 스크립트 추가

변경 요약:
-
---

## 기타 (Notes)
- 리뷰어가 알면 좋을 추가 맥락이나 TODO가 있다면 적어주세요.
close #51 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 인증 시스템에 사용자 프로필 이미지 URL 정보가 추가되었습니다. 로그인 및 토큰 갱신 시 프로필 이미지 URL이 포함되며, API 응답에서 이 정보를 활용할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->