### PR TITLE
✨ Feat : 수동 공고 삭제 api추가

### DIFF
--- a/src/controllers/jobsController.ts
+++ b/src/controllers/jobsController.ts
@@ -52,3 +52,29 @@ export async function getJobsHandler(req: Request, res: Response) {
     res.status(500).json({ error: "데이터 조회 중 오류가 발생했습니다." });
   }
 }
+
+export async function deleteManualJobHandler(req: Request, res: Response) {
+  try {
+    const userId = res.locals.user?.id;
+    const externalId = req.params.externalId as string;
+
+    if (!userId) {
+      return res.status(401).json({ error: "인증 정보가 없습니다." });
+    }
+
+    if (!externalId || typeof externalId !== 'string') {
+      return res.status(400).json({ error: "externalId가 필요합니다." });
+    }
+
+    const deleted = await jobsService.deleteManualJob(userId, externalId);
+
+    if (!deleted) {
+      return res.status(404).json({ error: "해당 공고를 찾을 수 없거나 삭제 권한이 없습니다." });
+    }
+
+    res.status(204).send();
+  } catch (error: any) {
+    console.error("DELETE /jobs/manual/:externalId error:", error);
+    res.status(500).json({ error: "공고 삭제 중 오류가 발생했습니다." });
+  }
+}

--- a/src/routes/jobsRoutes.ts
+++ b/src/routes/jobsRoutes.ts
@@ -72,4 +72,34 @@ router.post("/manual", requireAuth, jobsController.manualCrawlHandler);
  */
 router.get("/", requireAuth, jobsController.getJobsHandler);
 
+/**
+ * @swagger
+ * /jobs/manual/{externalId}:
+ *   delete:
+ *     summary: 수동 채용 공고 삭제
+ *     description: 본인이 등록한 수동 공고를 externalId로 삭제합니다. source_type=manual + external_id + created_by(userId) 3중 검증으로 본인 공고만 삭제 가능합니다.
+ *     tags: [Jobs]
+ *     security:
+ *       - cookieAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: externalId
+ *         required: true
+ *         description: 삭제할 공고의 external_id
+ *         schema:
+ *           type: string
+ *     responses:
+ *       204:
+ *         description: 삭제 성공 (응답 본문 없음)
+ *       400:
+ *         description: externalId 누락
+ *       401:
+ *         description: 인증 실패
+ *       404:
+ *         description: 해당 공고 없음 또는 삭제 권한 없음
+ *       500:
+ *         description: 서버 오류
+ */
+router.delete("/manual/:externalId", requireAuth, jobsController.deleteManualJobHandler);
+
 export default router;

--- a/src/services/jobsService.ts
+++ b/src/services/jobsService.ts
@@ -21,19 +21,22 @@ export async function crawlAndSaveJob(url: string, userId: string) {
     );
 
     const responseData = response.data as any;
-    const crawledData = (responseData && responseData.success && responseData.data) 
-      ? responseData.data as CrawledJob 
-      : responseData as CrawledJob;
+    const crawledData =
+      responseData && responseData.success && responseData.data
+        ? (responseData.data as CrawledJob)
+        : (responseData as CrawledJob);
 
-    // deadline 처리: timestamp 형식이 아니면 deadline_text에 저장
     const rawDeadline = String(crawledData.deadline || "").trim();
     let deadline = null;
     let deadlineText = null;
 
     if (rawDeadline) {
       const parsedDate = new Date(rawDeadline);
-      // 1. 숫자가 포함되어 있고 2. Date 객체로 변환 가능하며 3. 너무 짧지 않은 경우에만 날짜로 간주
-      if (!isNaN(parsedDate.getTime()) && /\d/.test(rawDeadline) && rawDeadline.length > 5) {
+      if (
+        !isNaN(parsedDate.getTime()) &&
+        /\d/.test(rawDeadline) &&
+        rawDeadline.length > 5
+      ) {
         deadline = parsedDate.toISOString();
       } else {
         deadlineText = rawDeadline;
@@ -52,12 +55,14 @@ export async function crawlAndSaveJob(url: string, userId: string) {
       experience: crawledData.experience || null,
       deadline: deadline,
       deadline_text: deadlineText,
-      external_id: String(crawledData.externalId || crawledData.external_id || ""),
+      external_id: String(
+        crawledData.externalId || crawledData.external_id || "",
+      ),
     };
 
     const { data, error } = await supabase
       .from(TABLE_NAME)
-      .upsert(jobData, { 
+      .upsert(jobData, {
         onConflict: "source_type,external_id", // 쉼표 사이 공백 제거
       })
       .select()
@@ -102,4 +107,24 @@ export async function getAutoJobs(limit: number = 50, offset: number = 0) {
   }
 
   return data || [];
+}
+
+export async function deleteManualJob(userId: string, externalId: string) {
+  const { data, error, count } = await supabase
+    .from(TABLE_NAME)
+    .delete({ count: "exact" })
+    .eq("source_type", "manual")
+    .eq("external_id", externalId)
+    .eq("created_by", userId)
+    .select()
+    .single();
+
+  if (error) {
+    if (error.code === "PGRST116") {
+      return null;
+    }
+    throw error;
+  }
+
+  return data;
 }


### PR DESCRIPTION
## 제목
<!-- 수동 공고 삭제 api추가 -->

## 개요 (Summary)
- 기존 수동 공고 api에 조회와 등록만 있어서 삭제를 추가했습니다.

## 관련 이슈 / 기획 문서
- 관련 이슈: #123 (있다면)
#39 

## 1. 변경 유형 (Type)
- [x] 기능 추가 (Feature)
- [ ] 버그 수정 (Bug fix)
- [ ] 리팩터링 (Refactor)
- [ ] 문서 (Docs)
- [ ] 인프라/배포 (Infra/DevOps)
- [ ] 기타 (Other, 아래에 설명)
---

## 2. 백엔드 상세 내용 (What changed)
- [x] API 추가/변경 (`/auth`, `/schedules`, `/resumes`, `/job-postings` 등)
- [ ] 서비스/도메인 로직
- [ ] 배치/크롤러 로직
- [ ] 인증/인가, 알림(메일 등)

변경 요약: DELETE /jobs/manual/:externalId
-
---
### 3. DB / ERD
- [ ] 테이블/컬럼 추가·수정
- [ ] 인덱스/제약 조건 변경
- [ ] 마이그레이션 스크립트 추가

변경 요약:
- 수동공고 delete api 추가
---

## 기타 (Notes)
- 수동공고에서 수정 api는 필요하지 않다고 생각해서 일단 조회, 등록, 삭제만 구현했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 수동으로 생성된 일자리 삭제 기능이 추가되었습니다. 인증된 사용자는 자신이 생성한 일자리를 삭제할 수 있으며, 적절한 오류 처리 및 검증이 포함되어 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->