### PR TITLE
🛠️ Fix : 지원현황페이징과 타임라인추가

### DIFF
--- a/src/controllers/applicationsController.ts
+++ b/src/controllers/applicationsController.ts
@@ -59,6 +59,14 @@ function toDbApplication(input: Record<string, unknown> = {}) {
 function toApiApplication(row: any) {
   if (!row) return row
   const status = row.application_statuses?.display_name ?? null
+  const histories = (row.application_status_histories ?? []).map((history: any) => ({
+    id: history.id,
+    fromStatusId: history.from_status_id,
+    toStatusId: history.to_status_id,
+    toStatusName: history.to_status_name ?? null,
+    changedByUserId: history.changed_by_user_id,
+    changedAt: history.changed_at ? String(history.changed_at).split('T')[0] : null,
+  }))
   return {
     id: row.id,
     jobPostingId: row.job_posting_id,
@@ -68,6 +76,7 @@ function toApiApplication(row: any) {
     appliedAt: row.applied_at,
     notes: row.notes,
     jobPostings: row.job_postings,
+    histories,
   }
 }
 
@@ -91,8 +100,24 @@ export async function listApplicationsByUser(req: AuthRequest, res: Response<any
     if (!userId) {
       return res.status(400).json({ error: '유효한 사용자 정보가 없습니다.' })
     }
-    const data = await getApplicationsByUser(userId)
-    res.status(200).json({ applications: data.map(toApiApplication) })
+
+    const rawLimit = typeof req.query.limit === 'string' ? Number(req.query.limit) : 20
+    const rawOffset = typeof req.query.offset === 'string' ? Number(req.query.offset) : 0
+    const limit = Number.isFinite(rawLimit) && rawLimit > 0 ? rawLimit : 20
+    const offset = Number.isFinite(rawOffset) && rawOffset >= 0 ? rawOffset : 0
+
+    const result = await getApplicationsByUser(userId, limit, offset)
+
+    res.status(200).json({
+      applications: result.items.map(toApiApplication),
+      pagination: {
+        totalCount: result.totalCount,
+        hasNext: result.hasNext,
+        nextOffset: result.nextOffset,
+        limit: result.limit,
+        offset: result.offset,
+      },
+    })
   } catch (err) {
     console.error('GET /applications/user', err)
     res.status(500).json({ error: '사용자 지원 내역 조회에 실패했습니다.' })

--- a/src/routes/applicationsRoutes.ts
+++ b/src/routes/applicationsRoutes.ts
@@ -16,18 +16,33 @@ const router = Router();
  * /applications/user:
  *   get:
  *     summary: 사용자 지원 현황 조회
- *     description: 인증된 사용자의 모든 지원 내역을 조회합니다.
+ *     description: 인증된 사용자의 지원 내역을 페이지네이션으로 조회합니다.
  *     tags:
  *       - Applications
  *     security:
  *       - cookieAuth: []
+ *     parameters:
+ *       - in: query
+ *         name: limit
+ *         required: false
+ *         schema:
+ *           type: integer
+ *           default: 20
+ *         description: 페이지 크기
+ *       - in: query
+ *         name: offset
+ *         required: false
+ *         schema:
+ *           type: integer
+ *           default: 0
+ *         description: 시작 위치(무한 스크롤 다음 요청 시 nextOffset 사용)
  *     responses:
  *       200:
  *         description: 지원 목록 조회 성공
  *         content:
  *           application/json:
  *             schema:
- *               $ref: '#/components/schemas/ApplicationsResponse'
+ *               $ref: '#/components/schemas/ApplicationsByUserResponse'
  *       401:
  *         description: 인증 실패
  */
@@ -246,6 +261,30 @@ router.delete('/:id', requireAuth, deleteApplicationHandler);
  *           type: object
  *           nullable: true
  *           description: 연관 채용공고 정보
+ *         histories:
+ *           type: array
+ *           description: 지원 상태 변경 히스토리 목록
+ *           items:
+ *             type: object
+ *             properties:
+ *               id:
+ *                 type: string
+ *               fromStatusId:
+ *                 type: string
+ *                 nullable: true
+ *               toStatusId:
+ *                 type: string
+ *               toStatusName:
+ *                 type: string
+ *                 nullable: true
+ *                 description: toStatusId에 해당하는 진행 상태명(display_name)
+ *               changedByUserId:
+ *                 type: string
+ *                 nullable: true
+ *               changedAt:
+ *                 type: string
+ *                 format: date
+ *                 example: 2026-03-27
  *     ApplicationResponse:
  *       type: object
  *       properties:
@@ -258,6 +297,32 @@ router.delete('/:id', requireAuth, deleteApplicationHandler);
  *           type: array
  *           items:
  *             $ref: '#/components/schemas/Application'
+ *     ApplicationsByUserResponse:
+ *       type: object
+ *       properties:
+ *         applications:
+ *           type: array
+ *           items:
+ *             $ref: '#/components/schemas/Application'
+ *         pagination:
+ *           type: object
+ *           properties:
+ *             totalCount:
+ *               type: integer
+ *               example: 123
+ *             hasNext:
+ *               type: boolean
+ *               example: true
+ *             nextOffset:
+ *               type: integer
+ *               nullable: true
+ *               example: 20
+ *             limit:
+ *               type: integer
+ *               example: 20
+ *             offset:
+ *               type: integer
+ *               example: 0
  *     ApplicationStatus:
  *       type: object
  *       properties:

--- a/src/services/applicationsService.ts
+++ b/src/services/applicationsService.ts
@@ -39,14 +39,45 @@ export async function getAllApplications() {
 export async function getApplicationById(id: string) {
   const { data, error } = await supabase
     .from(TABLE_NAME)
-    .select('*, application_statuses(display_name)')
+    .select('*, application_statuses(display_name), application_status_histories(to_status_id,changed_at)')
     .eq('id', id)
+    .order('changed_at', { foreignTable: STATUS_TABLE_NAME, ascending: true })
     .maybeSingle()
 
   if (error) {
     const e = new Error(error.message) as Error & { code?: string }
     e.code = error.code
     throw e
+  }
+
+  if (data?.application_status_histories?.length) {
+    const toStatusIds = Array.from(
+      new Set(
+        (data.application_status_histories as any[])
+          .map((history: any) => history?.to_status_id)
+          .filter((statusId: any) => typeof statusId === 'string' && statusId.length > 0)
+      )
+    )
+
+    if (toStatusIds.length > 0) {
+      const { data: statuses, error: statusesError } = await supabase
+        .from('application_statuses')
+        .select('id, display_name')
+        .in('id', toStatusIds)
+
+      if (statusesError) {
+        const e = new Error(statusesError.message) as Error & { code?: string }
+        e.code = statusesError.code
+        throw e
+      }
+
+      const statusNameMap = new Map((statuses ?? []).map((status: any) => [status.id, status.display_name]))
+
+      data.application_status_histories = (data.application_status_histories as any[]).map((history: any) => ({
+        ...history,
+        to_status_name: history?.to_status_id ? (statusNameMap.get(history.to_status_id) ?? null) : null,
+      }))
+    }
   }
 
   return data ?? null
@@ -165,12 +196,14 @@ export async function deleteApplication(id: string) {
   return data ?? []
 }
 
-export async function getApplicationsByUser(userId: string) {
-  const { data, error } = await supabase
+export async function getApplicationsByUser(userId: string, limit = 20, offset = 0) {
+  const { data, error, count } = await supabase
     .from(TABLE_NAME)
-    .select('*, job_postings(title, content, company_name), application_statuses(display_name)')
+    .select('*, job_postings(title, content, company_name), application_statuses(display_name)', { count: 'exact' })
     .eq('user_id', userId)
     .order('applied_at', { ascending: false })
+    .order('id', { ascending: false })
+    .range(offset, offset + limit - 1)
 
   if (error) {
     const e = new Error(error.message) as Error & { code?: string }
@@ -178,7 +211,19 @@ export async function getApplicationsByUser(userId: string) {
     throw e
   }
 
-  return data ?? []
+  const items = data ?? []
+  const totalCount = count ?? 0
+  const hasNext = offset + items.length < totalCount
+  const nextOffset = hasNext ? offset + items.length : null
+
+  return {
+    items,
+    totalCount,
+    hasNext,
+    nextOffset,
+    limit,
+    offset,
+  }
 }
 
 export async function getApplicationsByJob(jobPostingId: string) {


### PR DESCRIPTION
## 제목
지원현황 페이징, 총 갯수, 개별조회 타임라인추가

## 개요 (Summary)
- 지원현황 페이징, 총 갯수, 개별조회 타임라인추가

## 관련 이슈 / 기획 문서
- 관련 이슈: #43  (있다면)
---

## 1. 변경 유형 (Type)
- [x] 기능 추가 (Feature)
- [ ] 버그 수정 (Bug fix)
- [ ] 리팩터링 (Refactor)
- [ ] 문서 (Docs)
- [ ] 인프라/배포 (Infra/DevOps)
- [ ] 기타 (Other, 아래에 설명)
---

## 2. 백엔드 상세 내용 (What changed)
- [x] API 추가/변경 (`/auth`, `/schedules`, `/resumes`, `/job-postings` 등)
- [ ] 서비스/도메인 로직
- [ ] 배치/크롤러 로직
- [ ] 인증/인가, 알림(메일 등)

변경 요약:
-
---
### 3. DB / ERD
- [ ] 테이블/컬럼 추가·수정
- [ ] 인덱스/제약 조건 변경
- [ ] 마이그레이션 스크립트 추가

변경 요약:
-
---

## 기타 (Notes)
- 리뷰어가 알면 좋을 추가 맥락이나 TODO가 있다면 적어주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 애플리케이션의 상태 변경 이력을 조회할 수 있습니다.
  * 애플리케이션 목록 조회 시 페이지네이션을 지원하여 결과 개수를 제어할 수 있습니다.
  * 페이지네이션 메타데이터(총 개수, 다음 페이지 여부 등)가 응답에 포함됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->