### PR TITLE
🛠️ Fix : 포트폴리오파일 조회 오류 수정

### DIFF
--- a/src/services/portfolioService.ts
+++ b/src/services/portfolioService.ts
@@ -174,3 +174,18 @@ export async function finalizePortfolioFile(
   });
   return publicUrlData.publicUrl;
 }
+
+export async function generateSignedUrl(
+  storedFileUrl: string,
+  expiresIn = 3600, 
+): Promise<string | null> {
+  const objectPath = extractObjectPathFromUrl(storedFileUrl);
+  if (!objectPath) return null;
+
+  const { data, error } = await supabase.storage
+    .from(PORTFOLIO_BUCKET)
+    .createSignedUrl(objectPath, expiresIn);
+
+  if (error || !data?.signedUrl) return null;
+  return data.signedUrl;
+}

--- a/src/services/resumeService.ts
+++ b/src/services/resumeService.ts
@@ -9,6 +9,7 @@ import { ConflictError, NotFoundError } from "../utils/errors";
 import {
   deletePortfolioFilesFromUrls,
   finalizePortfolioFile,
+  generateSignedUrl,
 } from "./portfolioService";
 import { Portfolio } from "../types/resume";
 
@@ -97,6 +98,15 @@ export async function getResumeById(
 
   const content =
     typeof data.content === "string" ? JSON.parse(data.content) : data.content;
+
+    if (content.portfolio) {
+  for (const p of content.portfolio) {
+    if (p.fileUrl) {
+      const signedUrl = await generateSignedUrl(p.fileUrl);
+      if (signedUrl) p.fileUrl = signedUrl;
+    }
+  }
+}
 
   return {
     ...data,


### PR DESCRIPTION
## 제목
<!-- 예:포트폴리오파일 조회 오류 수정 -->

## 개요 (Summary)
- 이력서 조회 시에 포트폴리오 조회에서 403오류가 발생해서 수정

## 관련 이슈 / 기획 문서
- 관련 이슈: #80 
---

## 1. 변경 유형 (Type)
- [ ] 기능 추가 (Feature)
- [x] 버그 수정 (Bug fix)
- [ ] 리팩터링 (Refactor)
- [ ] 문서 (Docs)
- [ ] 인프라/배포 (Infra/DevOps)
- [ ] 기타 (Other, 아래에 설명)
---

## 2. 백엔드 상세 내용 (What changed)
- [ ] API 추가/변경 (`/auth`, `/schedules`, `/resumes`, `/job-postings` 등)
- [ ] 서비스/도메인 로직
- [ ] 배치/크롤러 로직
- [ ] 인증/인가, 알림(메일 등)

변경 요약:
-
---
### 3. DB / ERD
- [ ] 테이블/컬럼 추가·수정
- [ ] 인덱스/제약 조건 변경
- [ ] 마이그레이션 스크립트 추가

변경 요약:
- 포트폴리오 url 전달시 403에러 해결
---

## 기타 (Notes)
- 리뷰어가 알면 좋을 추가 맥락이나 TODO가 있다면 적어주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 포트폴리오 파일의 서명된 URL 생성 기능을 추가했습니다.
* 이력서 조회 시 포트폴리오 항목의 파일 링크가 자동으로 서명된 URL로 변환되어 제공됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->