### PR TITLE
🛠️ Fix : 수동공고 충돌문제 해결함

### DIFF
--- a/src/services/jobsService.ts
+++ b/src/services/jobsService.ts
@@ -107,13 +107,29 @@ export async function saveManualJob(
       external_id: data.externalId,
     };
 
-    const { data: saved, error } = await supabase
+    const { data: existing } = await supabase
       .from(TABLE_NAME)
-      .upsert(jobData, { onConflict: "source_type,external_id" })
-      .select()
-      .single();
+      .select("id")
+      .eq("source_type", "manual")
+      .eq("external_id", data.externalId)
+      .eq("created_by", userId)
+      .maybeSingle();
+
+    const { data: saved, error } = existing
+      ? await supabase
+          .from(TABLE_NAME)
+          .update(jobData)
+          .eq("id", existing.id)
+          .select()
+          .single()
+      : await supabase
+          .from(TABLE_NAME)
+          .insert(jobData)
+          .select()
+          .single();
 
     if (error) throw error;
+
 
     return convertKeysToCamel(saved);
   } catch (error: any) {


### PR DESCRIPTION
## 제목
<!-- 수동공고 충돌문제 수정-->

## 개요 (Summary)
- 수동공고 수정에 사용자 확인이 빠져있어 충돌이 일어날 가능성이 있어 코드 수정했습니다.

## 관련 이슈 / 기획 문서
- 관련 이슈: x
---

## 1. 변경 유형 (Type)
- [ ] 기능 추가 (Feature)
- [x] 버그 수정 (Bug fix)
- [ ] 리팩터링 (Refactor)
- [ ] 문서 (Docs)
- [ ] 인프라/배포 (Infra/DevOps)
- [ ] 기타 (Other, 아래에 설명)
---

## 2. 백엔드 상세 내용 (What changed)
- [ ] API 추가/변경 (`/auth`, `/schedules`, `/resumes`, `/job-postings` 등)
- [ ] 서비스/도메인 로직
- [ ] 배치/크롤러 로직
- [ ] 인증/인가, 알림(메일 등)

변경 요약:
-
---
### 3. DB / ERD
- [ ] 테이블/컬럼 추가·수정
- [ ] 인덱스/제약 조건 변경
- [ ] 마이그레이션 스크립트 추가

변경 요약:
- upsert 로직을 수정
- saveManualJob 호출
    ↓
내 소유의 같은 externalId 공고 있는지 확인
  (source_type=manual + external_id=X + created_by=나)
    ↓
있음 → UPDATE (내 공고만 수정)
없음 → INSERT (새로 생성)

결과: 사용자 A와 B가 같은 URL 저장해도 각자 독립적인 행으로 분리 
---

## 기타 (Notes)
- 리뷰어가 알면 좋을 추가 맥락이나 TODO가 있다면 적어주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 수동 작업 저장 시 사용자별 중복 검사 로직 개선 - 동일한 외부 ID를 가진 작업이라도 다른 사용자가 생성한 경우 별도로 관리됨

<!-- end of auto-generated comment: release notes by coderabbit.ai -->