### PR TITLE
🛠️ Fix : 스크랩스웨거 수정

### DIFF
--- a/src/routes/scrapsRoutes.ts
+++ b/src/routes/scrapsRoutes.ts
@@ -77,13 +77,16 @@ router.post('/:jobPostingId', requireAuth, toggleScrapHandler);
  *         required: false
  *         schema:
  *           type: integer
- *           default: 20
+ *           default: 30
+ *           minimum: 1
+ *           maximum: 100
  *       - in: query
  *         name: offset
  *         required: false
  *         schema:
  *           type: integer
  *           default: 0
+ *           minimum: 0
  *       - in: query
  *         name: sortBy
  *         required: false
@@ -129,6 +132,33 @@ router.post('/:jobPostingId', requireAuth, toggleScrapHandler);
  *                       createdAt:
  *                         type: string
  *                         example: 2026-03-25
+ *                 pagination:
+ *                   type: object
+ *                   properties:
+ *                     totalCount:
+ *                       type: integer
+ *                       description: 전체 스크랩 수
+ *                     hasNext:
+ *                       type: boolean
+ *                       description: 다음 페이지 존재 여부
+ *                     nextOffset:
+ *                       type: integer
+ *                       nullable: true
+ *                       description: 다음 페이지 offset (hasNext가 false면 null)
+ *                     limit:
+ *                       type: integer
+ *                     offset:
+ *                       type: integer
+ *       400:
+ *         description: 유효하지 않은 파라미터
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                   example: limit은 1~100 사이의 정수여야 합니다.
  *       401:
  *         description: 인증 실패
  *       500:


### PR DESCRIPTION
## 제목
스크랩 스웨거 최신화

## 개요 (Summary)
- 이 PR에서 **무엇을** / **왜** 변경했는지 간단히 정리해주세요.

## 관련 이슈 / 기획 문서
- 관련 이슈: #123 (있다면)
---

## 1. 변경 유형 (Type)
- [ ] 기능 추가 (Feature)
- [ ] 버그 수정 (Bug fix)
- [ ] 리팩터링 (Refactor)
- [ ] 문서 (Docs)
- [ ] 인프라/배포 (Infra/DevOps)
- [ ] 기타 (Other, 아래에 설명)
---

## 2. 백엔드 상세 내용 (What changed)
- [ ] API 추가/변경 (`/auth`, `/schedules`, `/resumes`, `/job-postings` 등)
- [ ] 서비스/도메인 로직
- [ ] 배치/크롤러 로직
- [ ] 인증/인가, 알림(메일 등)

변경 요약:
-
---
### 3. DB / ERD
- [ ] 테이블/컬럼 추가·수정
- [ ] 인덱스/제약 조건 변경
- [ ] 마이그레이션 스크립트 추가

변경 요약:
-
---

## 기타 (Notes)
- 리뷰어가 알면 좋을 추가 맥락이나 TODO가 있다면 적어주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 설명서

* **설명서**
  * `/scraps` 엔드포인트의 기본 조회 제한값이 20에서 30으로 변경되었습니다.
  * API 응답에 페이지네이션 정보(전체 개수, 다음 페이지 존재 여부, 오프셋)가 추가되었습니다.
  * 입력 유효성 검사 범위 및 오류 응답 내용이 명시되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->